### PR TITLE
Fixes the harmful changes made to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,42 +31,29 @@ Possible Adaptations
 
 Installation
 ---
-Linux
+### Linux
 
-```
-# clone pro-grid:
-git clone git@github.com:$GITHUB_USER/$REPO.git
-cd $REPO
-
+```bash
 # checkout working branch
 git checkout fix4
 
-intall RVM:
-\curl -L https://get.rvm.io | bash -s stable
-source ~/.rvm/scripts/rvm
-rvm requirements
-rvm install ruby
-rvm use ruby --default
-rvm rubygems current
-gem install rails
+# install RVM (optional)
+# read this https://rvm.io/rvm/install
 gem install compass
 
 # install node.js
-sudo apt-get update
-sudo apt-get install python-software-properties
-sudo apt-add-repository ppa:chris-lea/node.js
-sudo apt-get update
-sudo apt-get install nodejs
+# read this https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager
 
 # install grunt and bower
-sudo npm install -g n
-sudo npm install -g grunt-cli
-sudo npm install -g bower
-sudo npm install grunt-contrib-compass --save-dev
+npm install -g n
+n stable
+npm install -g grunt-cli
+npm install -g bower
+npm install
 bower install
 ```
 
-Windows
+### Windows
 
  - Ruby: http://rubyinstaller.org/
  - Git: http://git-scm.com/downloads


### PR DESCRIPTION
Last night a lot of stuff that makes no sense was added to the readme
- removes instructions to clone the repo, this is obvious to any open source contributor
- removes instructions to install rvm and directs the user to the RVM docs
- removes rails installation from dependency. wtf would you need rails for?
- adds proper instructions for installing node from a package manager
- proper instructions for initializing n
- run npm install instead of installing grunt-contrib-compass 
- removes all references to sudo

references issue #6
